### PR TITLE
Fix compilation failure on Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlotlyKaleido"
 uuid = "f2990250-8cf9-495f-b13a-cce12b45703c"
 authors = ["Simon Christ <christ@cell.uni-hannover.de>", "Spencer Lyon <spencerlyon2@gmail.com>"]
-version = "1.0.0"
+version = "2.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ This code was originally part of [PlotlyJS.jl](https://github.com/JuliaPlots/Plo
 
 ```julia
 using PlotlyKaleido
-
 import PlotlyLight, EasyConfig, PlotlyJS
+
+PlotlyKaleido.start()  # start Kaleido server
 
 p1 = PlotlyLight.Plot(EasyConfig.Config(x = rand(10)))
 
@@ -34,4 +35,16 @@ p2 = PlotlyJS.plot(PlotlyJS.scatter(x = rand(10)))
 # PlotlyKaleido is agnostic about which package you use to make Plotly plots!
 PlotlyKaleido.savefig(p1, "plot1.png")
 PlotlyKaleido.savefig(p2, "plot2.png")
+```
+
+If needed, you can restart the server:
+
+```julia
+PlotlyKaleido.restart()
+```
+
+or simply kill it:
+
+```julia
+PlotlyKaleido.kill_kaleido()
 ```

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -6,8 +6,6 @@ using Kaleido_jll
 
 export savefig
 
-__init__() = @info "Attention: PlotlyKaleido v2.0 has breaking changes. See the README for details."
-
 #-----------------------------------------------------------------------------# Kaleido Process
 mutable struct Pipes
     stdin::Pipe

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -19,7 +19,7 @@ end
 
 const P = Pipes()
 
-kill_kaleido() = is_running() && kill_kaleido(P.proc)
+kill_kaleido() = is_running() && kill(P.proc)
 
 is_running() = isdefined(P, :proc) && isopen(P.stdin) && process_running(P.proc)
 

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -6,7 +6,7 @@ using Kaleido_jll
 
 export savefig
 
-__init__() = start()
+__init__() = @info "Attention: PlotlyKaleido v2.0 has breaking changes. See the README for details."
 
 #-----------------------------------------------------------------------------# Kaleido Process
 mutable struct Pipes
@@ -19,11 +19,11 @@ end
 
 const P = Pipes()
 
-kill() = is_running() && kill(P.proc)
+kill_kaleido() = is_running() && kill_kaleido(P.proc)
 
 is_running() = isdefined(P, :proc) && isopen(P.stdin) && process_running(P.proc)
 
-restart() = (kill(); start())
+restart() = (kill_kaleido(); start())
 
 function start()
     is_running() && return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test
 @test_nowarn @eval using PlotlyKaleido
 
+PlotlyKaleido.start()
+
 import PlotlyLight, EasyConfig, PlotlyJS
 
 @testset "Saving JSON String" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test
-@test_nowarn @eval using PlotlyKaleido
+using PlotlyKaleido
 
 PlotlyKaleido.start()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test
-using PlotlyKaleido
+@test_nowarn @eval using PlotlyKaleido
 
 PlotlyKaleido.start()
 


### PR DESCRIPTION
Julia 1.10 requires that no I/O resources are left open during module initialization. Thus, the code:

```julia
__init__() = start()
```

needs to be removed, and the user must call

```julia
PlotlyKaleido.start()
```

manually upon initialization.

I have implemented these changes. I have also updated the package version to 2.0 so that this does not introduce breaking changes in any existing dependent projects (though they will soon break anyways).

I also fixed a bug where `kill()` is defined incorrectly, as it conflicts with `Base.kill()`. It is now `kill_kaleido`.

Fixes #5 

@BeastyBlacksmith would you be willing to merge this relatively quickly? This is currently breaking my package AirspeedVelocity.jl on Julia 1.10.