### PR TITLE
Support providing extra flags to `start()` and `restart()`

### DIFF
--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -21,13 +21,24 @@ kill_kaleido() = is_running() && kill(P.proc)
 
 is_running() = isdefined(P, :proc) && isopen(P.stdin) && process_running(P.proc)
 
-restart() = (kill_kaleido(); start())
+restart(;extra_flags...) = (kill_kaleido(); sleep(0.1); start(;extra_flags...))
 
-function start()
+function start(;extra_flags...)
     is_running() && return
-
     cmd = joinpath(Kaleido_jll.artifact_dir, "kaleido" * (Sys.iswindows() ? ".cmd" : ""))
-    BIN = Sys.isapple() ? `$(cmd) plotly --disable-gpu --single-process` : `$(cmd) plotly --disable-gpu --no-sandbox`
+    basic_cmds = [cmd, "plotly"]
+    chromium_flags = ["--disable-gpu", Sys.isapple() ? "--single-process" : "--no-sandbox"]
+    # Taken inspiration from https://github.com/plotly/Kaleido/blob/3b590b563385567f257db8ff27adae1adf77821f/repos/kaleido/py/kaleido/scopes/base.py#L116-L141
+    user_flags = String[]
+    for (k,v) in extra_flags
+        flag_name = replace(string(k), "_" => "-")
+        if v isa Bool
+            v && push!(user_flags, "--$flag_name")
+        else
+            push!(user_flags, "--$flag_name=$v")
+        end
+    end
+    BIN  = Cmd(vcat(basic_cmds, chromium_flags, user_flags))
 
     kstdin = Pipe()
     kstdout = Pipe()


### PR DESCRIPTION
Initial attempt at fixing #7 by providing a way to give extra flags for the kaleido process.
Fixes #7

This would allow passing explicitly the URL of the desired plotly version using kwargs.

I based the flags parsing code on the original python code inside the Kaleido library here:

https://github.com/plotly/Kaleido/blob/3b590b563385567f257db8ff27adae1adf77821f/repos/kaleido/py/kaleido/scopes/base.py#L116-L141

I also added a small sleep inside the `restart()` function due to the issue presented in #8 