### PR TITLE
Enable MathJax functionality

### DIFF
--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -17,6 +17,8 @@ end
 
 const P = Pipes()
 
+const _mathjax_url = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js"
+
 kill_kaleido() = is_running() && kill(P.proc)
 
 is_running() = isdefined(P, :proc) && isopen(P.stdin) && process_running(P.proc)
@@ -27,7 +29,7 @@ function start(;plotly_version = missing, kwargs...)
     is_running() && return
     cmd = joinpath(Kaleido_jll.artifact_dir, "kaleido" * (Sys.iswindows() ? ".cmd" : ""))
     basic_cmds = [cmd, "plotly"]
-    chromium_flags = ["--disable-gpu", Sys.isapple() ? "--single-process" : "--no-sandbox"]
+    chromium_flags = ["--disable-gpu", Sys.isapple() ? "--single-process" : "--no-sandbox",  "--mathjax=$(_mathjax_url)"]
     extra_flags = if plotly_version === missing
         (;
             kwargs...


### PR DESCRIPTION
Enable LaTeX to appear in images produced using savefig().

Note that LaTeX rendering in VS Code doesn't seem to work. This applies to saved figures however.

MWE
```
julia> using LaTeXStrings

julia> using PlotlyKaleido

julia> import PlotlyJS

julia> import PlotlyJS: scatter, attr, Layout

julia> p2 = PlotlyJS.plot(PlotlyJS.scatter(x = rand(10)), Layout(
                       font_size=14,
                       margin=attr(l=80, r=60, b=60, t=80),
                       title = "My Plot",
                       xaxis_title = L"\sqrt{N_c}".s,
                       yaxis_title = L"\int r".s))

julia> PlotlyKaleido.start()

julia> PlotlyKaleido.savefig(p2, "plot3.pdf")
"plot3.pdf"
```

Before:
![plot4](https://github.com/JuliaPlots/PlotlyKaleido.jl/assets/38274066/2d7d64e2-3d2f-4736-b8e0-8f31c6de16ad)

After:
![plot3](https://github.com/JuliaPlots/PlotlyKaleido.jl/assets/38274066/f982aa08-6090-4bc7-9a3e-6eb7896c86f9)

 