### PR TITLE
Call the kaleido binary directly (fixes permission errors on Windows and Julia 1.10)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,11 @@ julia = "1.6"
 Kaleido_jll = "0.1, 0.2"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-PlotlyLight = "ca7969ec-10b3-423e-8d99-40f33abb42bf"
 EasyConfig = "acab07b0-f158-46d4-8913-50acef6d41fe"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+PlotlyLight = "ca7969ec-10b3-423e-8d99-40f33abb42bf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test", "PlotlyLight", "EasyConfig", "PlotlyJS"]
+test = ["Test", "PlotlyLight", "EasyConfig", "PlotlyJS", "Pkg"]

--- a/README.md
+++ b/README.md
@@ -53,3 +53,8 @@ To enable LaTeX (using MathJax v2) in plots, use the keyword argument `mathjax`:
 ```julia
 PlotlyKaleido.start(mathjax=true)  # start Kaleido server with MathJax enabled
 ```
+
+## Windows Note
+Many people one Windows have issues with the latest (0.2.1) version of the Kaleido library (see for example [discourse](https://discourse.julialang.org/t/plotlyjs-causes-errors-cant-figure-out-how-to-use-plotlylight-how-to-use-plotly-from-julia/108853/29), [this PR's comment](https://github.com/JuliaPlots/PlotlyKaleido.jl/pull/17#issuecomment-1969325440) and [this issue](https://github.com/plotly/Kaleido/issues/134) on the Kaleido repository).
+
+Many people have succesfully fixed this problem on windows by downgrading the kaleido library to version 0.1.0 (see [the previously mentioned issue](https://github.com/plotly/Kaleido/issues/134)). If you experience issues with `PlotlyKaleido.start()` hanging on windows, you may want try adding `Kaledido_jll@v0.1` explicitly to your project environment to fix this.

--- a/README.md
+++ b/README.md
@@ -57,4 +57,14 @@ PlotlyKaleido.start(mathjax=true)  # start Kaleido server with MathJax enabled
 ## Windows Note
 Many people one Windows have issues with the latest (0.2.1) version of the Kaleido library (see for example [discourse](https://discourse.julialang.org/t/plotlyjs-causes-errors-cant-figure-out-how-to-use-plotlylight-how-to-use-plotly-from-julia/108853/29), [this PR's comment](https://github.com/JuliaPlots/PlotlyKaleido.jl/pull/17#issuecomment-1969325440) and [this issue](https://github.com/plotly/Kaleido/issues/134) on the Kaleido repository).
 
-Many people have succesfully fixed this problem on windows by downgrading the kaleido library to version 0.1.0 (see [the previously mentioned issue](https://github.com/plotly/Kaleido/issues/134)). If you experience issues with `PlotlyKaleido.start()` hanging on windows, you may want try adding `Kaledido_jll@v0.1` explicitly to your project environment to fix this.
+Many people have succesfully fixed this problem on windows by downgrading the kaleido library to version 0.1.0 (see [the previously mentioned issue](https://github.com/plotly/Kaleido/issues/134)). If you experience issues with `PlotlyKaleido.start()` hanging on windows, you may want try adding `Kaledido_jll@v0.1` explicitly to your project environment to fix this. You can do so by either doing:
+```julia
+add Kaleido_jll@v0.1
+```
+inside the REPL package enviornment, or by calling the following code in the REPL directly:
+```julia
+begin
+    import Pkg
+    Pkg.add(; name = "Kaleido_jll", version = "0.1")
+end
+```

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -33,7 +33,8 @@ function start(;
     kwargs...,
 )
     is_running() && return
-    cmd = joinpath(Kaleido_jll.artifact_dir, "kaleido" * (Sys.iswindows() ? ".cmd" : ""))
+    bin_name = Sys.iswindows() ? joinpath("bin", "kaleido.exe") : "kaleido"
+    cmd = joinpath(Kaleido_jll.artifact_dir, bin_name)
     basic_cmds = [cmd, "plotly"]
     chromium_flags = ["--disable-gpu", Sys.isapple() ? "--single-process" : "--no-sandbox"]
     extra_flags = if plotly_version === missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,11 @@ end
 @test_nowarn @eval using PlotlyKaleido
 
     @testset "Start" begin
-    if Sys.iswindows()
-        PlotlyKaleido.start()
-    else
+    # if Sys.iswindows()
+    #     PlotlyKaleido.start()
+    # else
         @test_nowarn PlotlyKaleido.start()
-    end
+    # end
     @test PlotlyKaleido.is_running()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,8 @@ if Sys.iswindows()
 end
 @test_nowarn @eval using PlotlyKaleido
 
+PlotlyKaleido.start()
 @testset "Start" begin
-    @test_nowarn PlotlyKaleido.start()
     @test PlotlyKaleido.is_running()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,12 @@ if Sys.iswindows()
 end
 @test_nowarn @eval using PlotlyKaleido
 
-PlotlyKaleido.start()
-@testset "Start" begin
+    @testset "Start" begin
+    if Sys.iswindows()
+        PlotlyKaleido.start()
+    else
+        @test_nowarn PlotlyKaleido.start()
+    end
     @test PlotlyKaleido.is_running()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
 using Test
+import Pkg
+if Sys.iswindows()
+    # Fix kaleido tests on windows due to Kaleido_jll@v0.2.1 hanging
+    Pkg.add(;name = "Kaleido_jll", version = "0.1")
+end
 @test_nowarn @eval using PlotlyKaleido
 
 @testset "Start" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,11 @@ end
 @test_nowarn @eval using PlotlyKaleido
 
     @testset "Start" begin
-    # if Sys.iswindows()
-    #     PlotlyKaleido.start()
-    # else
+    if Sys.iswindows()
+        PlotlyKaleido.start()
+    else
         @test_nowarn PlotlyKaleido.start()
-    # end
+    end
     @test PlotlyKaleido.is_running()
 end
 


### PR DESCRIPTION
Since 1.10 there have been various issue with PlotlyKaleido on windows.
One of the encountered issues seems to be related to artifacts permissions.

I had some tests on my windows machine with julia 1.10.1 where Kaleido fails to start due to a permission error:
```julia
julia> using Kaleido_jll

julia> run(`$(joinpath(Kaleido_jll.artifact_dir, "kaleido.cmd")) plotly`)
Access is denied.
The system cannot find the path specified.
ERROR: failed process: Process(`'C:\Users\Alberto.Mengali\.julia\artifacts\7914a56da888d6a06d00c87f97e873c60e97acc7\kaleido.cmd' plotly`, ProcessExited(1)) [1]

Stacktrace:
 [1] pipeline_error
   @ .\process.jl:565 [inlined]
 [2] run(::Cmd; wait::Bool)
   @ Base .\process.jl:480
 [3] run(::Cmd)
   @ Base .\process.jl:477
 [4] top-level scope
   @ REPL[11]:1
```
I noticed that I only get permission denied if trying to execute the `kaleido.cmd` script, and not the kaleido executable directly.

This is the content of `kaleido.cmd` on windows:
```batch
@echo off
setlocal
chdir /d "%~dp0"
.\bin\kaleido.exe %*
```

which does not seem to do anything really useful for our use case where we can point directly to the path of the executable.

This PR changes the path of the bin used by PlotlyKaleido to point to `kaleido.exe` directly instead of going through the script file above, hoping it will fix this error with permission on windows