### PR TITLE
Make all errors in `start` warnings, actually throw when calling `save_payload`

### DIFF
--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -59,9 +59,11 @@ function readline_noblock(io; timeout = 10)
     wait(task)
     kaleido_version = read(joinpath(Kaleido_jll.artifact_dir, "version"), String)
     out = take!(msg)
-    out === "Stopped" && seterror("It looks like the Kaleido (version $(kaleido_version)) process is hanging.
-If you are on Windows this might be caused by known problems with Kaleido v0.2 on Windows.
-You might want to try forcing a downgrade of the kaleido library to 0.1.
+    out === "Stopped" && seterror("It looks like the Kaleido process is hanging. 
+The unresponsive process will be killed, but this means that you will not be able to save figures using `savefig`.
+
+If you are on Windows this might be caused by known problems with Kaleido v0.2 on Windows (you are using version $(kaleido_version)).
+You might want to try forcing a downgrade of the Kaleido_jll library to 0.1.
 Check the Package Readme at https://github.com/JuliaPlots/PlotlyKaleido.jl/tree/main#windows-note for more details.
 
 If you think this is not your case, you might try using a longer timeout to check if the process is not responding (defaults to 10 seconds) by passing the desired value in seconds using the `timeout` kwarg when calling `PlotlyKaleido.start` or `PlotlyKaleido.restart`")

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -48,7 +48,7 @@ function readline_noblock(io)
     end
 
     interrupter = Task() do
-        sleep(5)
+        sleep(10)
         if !istaskdone(task)
             Base.throwto(task, InterruptException())
         end

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -139,7 +139,7 @@ function start(;
 
     res = readline_noblock(P.stdout; timeout)  # {"code": 0, "message": "Success", "result": null, "version": "0.2.1"}
     length(res) == 0 && warn_and_kill("Kaleido startup failed.")
-    if !is_running()
+    if is_running()
         code = JSON.parse(res)["code"]
         code == 0 || warn_and_kill("Kaleido startup failed with code $code.")
     end

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -139,7 +139,7 @@ function start(;
 
     res = readline_noblock(P.stdout; timeout)  # {"code": 0, "message": "Success", "result": null, "version": "0.2.1"}
     length(res) == 0 && warn_and_kill("Kaleido startup failed.")
-    if !haserror()
+    if !is_running()
         code = JSON.parse(res)["code"]
         code == 0 || warn_and_kill("Kaleido startup failed with code $code.")
     end
@@ -153,7 +153,7 @@ const TEXT_FORMATS = ["svg", "json", "eps"]
 
 
 function save_payload(io::IO, payload::AbstractString, format::AbstractString)
-    isrunning() || error("It looks like the Kaleido process is not running, so you can not save plotly figures.
+    is_running() || error("It looks like the Kaleido process is not running, so you can not save plotly figures.
 Remember to start the process before using `savefig` by calling `PlotlyKaleido.start()`.
 If the process was killed due to an error during initialization, you will receive a warning when the `PlotlyKaleido.start` function is executing")
     format in ALL_FORMATS || error("Unknown format $format. Expected one of $ALL_FORMATS")


### PR DESCRIPTION
This PR tries to fix https://github.com/JuliaPlots/PlotlyJS.jl/issues/482

For consistency, now all errors encountered during `start()` are just sent as warning and only thrown when calling `save_payload`.

This should not break precompilation of PlotlyJS but the actual error message will not be thrown in `PlotlyJS` as a custom `savefig` implementation is used (which does not call `PlotlyKaleido.savefig`)