### PR TITLE
Fix passing user flags to kaleido executable

### DIFF
--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -117,7 +117,7 @@ function start(;
         end
     end
     # We add the flags to the BIN
-    append!(BIN.exec, chromium_flags, extra_flags)
+    append!(BIN.exec, chromium_flags, user_flags)
 
     kstdin = Pipe()
     kstdout = Pipe()


### PR DESCRIPTION
This PR fixes passing user arguments to `start`. 

For example, the following currently fails to correctly pass the desired offline path to plotlyjs to the kaleido executable. It is fixed by this PR.

```julia
PlotlyKaleido.start(plotlyjs="/path/to/plotly-latest.min.js") 
```
