### PR TITLE
Manually use Kaleido@v0.1 on windows with explicit artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,16 @@
+[[Kaleido_fallback]]
+arch = "i686"
+git-tree-sha1 = "2c005b45d9aaa0e217791b3431d9e61e18806cd1"
+os = "windows"
+
+    [[Kaleido_fallback.download]]
+    sha256 = "4b81d3f958281f53bb2f462d2745766f615a6d094b2cc59a0b03fe38c73d1b8a"
+    url = "https://github.com/JuliaBinaryWrappers/Kaleido_jll.jl/releases/download/Kaleido-v0.1.0+0/Kaleido.v0.1.0.i686-w64-mingw32.tar.gz"
+[[Kaleido_fallback]]
+arch = "x86_64"
+git-tree-sha1 = "aa3e0157eff69c2604027b85f1ff85a59bfae52f"
+os = "windows"
+
+    [[Kaleido_fallback.download]]
+    sha256 = "52bce20e749b9955ee4dd3b22fa44dbdc9a6c4a4d447e243d8c016d4b730d496"
+    url = "https://github.com/JuliaBinaryWrappers/Kaleido_jll.jl/releases/download/Kaleido-v0.1.0+0/Kaleido.v0.1.0.x86_64-w64-mingw32.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -4,21 +4,23 @@ authors = ["Simon Christ <christ@cell.uni-hannover.de>", "Spencer Lyon <spencerl
 version = "2.2.5"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Kaleido_jll = "f7e6163d-2fa5-5f23-b69c-1db539e41963"
 
 [compat]
+Artifacts = "1"
 JSON = "0.21"
-julia = "1.6"
 Kaleido_jll = "0.1, 0.2"
+julia = "1.6"
 
 [extras]
 EasyConfig = "acab07b0-f158-46d4-8913-50acef6d41fe"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 PlotlyLight = "ca7969ec-10b3-423e-8d99-40f33abb42bf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
 test = ["Test", "PlotlyLight", "EasyConfig", "PlotlyJS", "Pkg"]

--- a/README.md
+++ b/README.md
@@ -67,4 +67,8 @@ begin
     import Pkg
     Pkg.add(; name = "Kaleido_jll", version = "0.1")
 end
+
+The package will now default to using an explicitly provided version of Kaleido 0.1 on Windows systems without requiring to explicitly fix the version of `Kaleido_jll` in your project environment.
+
+To disable this automatic fallback, you can set `PlotlyKaleido.USE_KALEIDO_FALLBACK[] = false`.
 ```

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -1,10 +1,18 @@
 module PlotlyKaleido
 
 using JSON: JSON
+using Artifacts: @artifact_str
 using Base64: Base64
 using Kaleido_jll: Kaleido_jll
 
 export savefig
+
+#-----------------------------------------------------------------------------# Windows Fallback
+
+should_try_fallback() = Sys.iswindows() && (get_kaleido_version() !== "0.1.0")
+get_kaleido_version() = read(joinpath(Kaleido_jll.artifact_dir, "version"), String)
+
+const USE_KALEIDO_FALLBACK = Ref(should_try_fallback())
 
 #-----------------------------------------------------------------------------# Kaleido Process
 mutable struct Pipes
@@ -54,7 +62,7 @@ function readline_noblock(io; timeout = 10)
     schedule(interrupter)
     schedule(task)
     wait(task)
-    kaleido_version = read(joinpath(Kaleido_jll.artifact_dir, "version"), String)
+    kaleido_version = get_kaleido_version()
     out = take!(msg)
     out === "Stopped" && warn_and_kill("It looks like the Kaleido process is not responding. 
 The unresponsive process will be killed, but this means that you will not be able to save figures using `savefig`.
@@ -67,6 +75,18 @@ If you think this is not your case, you might try using a longer timeout to chec
     return out
 end
 
+function get_base_cmd()
+    cmd = if should_try_fallback() && USE_KALEIDO_FALLBACK[]
+        # For the fallback we don't fully reproduce the jll machinery as this is much simpler and should work fine for kaleido specifically on windows.
+        dir = artifact"Kaleido_fallback"
+        Cmd(`$(joinpath(dir, "bin", "kaleido.exe"))`; dir)
+    else
+        dir = Kaleido_jll.artifact_dir
+        Cmd(Kaleido_jll.kaleido(); dir)
+    end
+    return cmd
+end
+
 function start(;
     plotly_version = missing,
     mathjax = missing,
@@ -76,7 +96,7 @@ function start(;
 )
     is_running() && return
     # The kaleido executable must be run from the artifact directory
-    BIN = Cmd(Kaleido_jll.kaleido(); dir = Kaleido_jll.artifact_dir)
+    BIN = get_base_cmd()
     # We push the mandatory plotly flag
     push!(BIN.exec, "plotly")
     chromium_flags = ["--disable-gpu", Sys.isapple() ? "--single-process" : "--no-sandbox"]

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -9,6 +9,12 @@ export savefig
 
 #-----------------------------------------------------------------------------# Windows Fallback
 
+const FALLBACK_DIR = @static if Sys.iswindows()
+    artifact"Kaleido_fallback"
+else
+    ""
+end
+
 should_try_fallback() = Sys.iswindows() && (get_kaleido_version() !== "0.1.0")
 get_kaleido_version() = read(joinpath(Kaleido_jll.artifact_dir, "version"), String)
 
@@ -78,7 +84,7 @@ end
 function get_base_cmd()
     cmd = if should_try_fallback() && USE_KALEIDO_FALLBACK[]
         # For the fallback we don't fully reproduce the jll machinery as this is much simpler and should work fine for kaleido specifically on windows.
-        dir = artifact"Kaleido_fallback"
+        dir = FALLBACK_DIR
         Cmd(`$(joinpath(dir, "bin", "kaleido.exe"))`; dir)
     else
         dir = Kaleido_jll.artifact_dir

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -15,8 +15,8 @@ else
     ""
 end
 
-should_try_fallback() = Sys.iswindows() && (get_kaleido_version() !== "0.1.0")
 get_kaleido_version() = read(joinpath(Kaleido_jll.artifact_dir, "version"), String)
+should_try_fallback() = Sys.iswindows() && (get_kaleido_version() !== "0.1.0")
 
 const USE_KALEIDO_FALLBACK = Ref(should_try_fallback())
 
@@ -68,7 +68,6 @@ function readline_noblock(io; timeout = 10)
     schedule(interrupter)
     schedule(task)
     wait(task)
-    kaleido_version = get_kaleido_version()
     out = take!(msg)
     if out === "Stopped" 
         warn_str = "It looks like the Kaleido process is not responding since $(timeout) seconds. 
@@ -76,11 +75,13 @@ The unresponsive process will be killed, but this means that you will not be abl
 
         if should_try_fallback() && !USE_KALEIDO_FALLBACK[]
             warn_str *= "
+
 You seem to be on Windows but have disabled the automatic fallback to version 0.1 of Kaleido. You may want to try enabling it by calling `PlotlyKaleido.USE_KALEIDO_FALLBACK[] = true`, as higher version of Kaleido are known to have issues on Windows.
 Check the Package Readme at https://github.com/JuliaPlots/PlotlyKaleido.jl/tree/main#windows-note for more details."
         end
 
         warn_str *= "
+
 Alternatively, you might try using a longer timeout to check if the process is not responding by passing the desired value in seconds using the `timeout` kwarg when calling `PlotlyKaleido.start` or `PlotlyKaleido.restart`"
         warn_and_kill(warn_str)
     end

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -70,14 +70,20 @@ function readline_noblock(io; timeout = 10)
     wait(task)
     kaleido_version = get_kaleido_version()
     out = take!(msg)
-    out === "Stopped" && warn_and_kill("It looks like the Kaleido process is not responding. 
-The unresponsive process will be killed, but this means that you will not be able to save figures using `savefig`.
+    if out === "Stopped" 
+        warn_str = "It looks like the Kaleido process is not responding since $(timeout) seconds. 
+The unresponsive process will be killed, but this means that you will not be able to save figures using `savefig`."
 
-If you are on Windows this might be caused by known problems with Kaleido v0.2 on Windows (you are using version $(kaleido_version)).
-You might want to try forcing a downgrade of the Kaleido_jll library to 0.1.
-Check the Package Readme at https://github.com/JuliaPlots/PlotlyKaleido.jl/tree/main#windows-note for more details.
+        if should_try_fallback() && !USE_KALEIDO_FALLBACK[]
+            warn_str *= "
+You seem to be on Windows but have disabled the automatic fallback to version 0.1 of Kaleido. You may want to try enabling it by calling `PlotlyKaleido.USE_KALEIDO_FALLBACK[] = true`, as higher version of Kaleido are known to have issues on Windows.
+Check the Package Readme at https://github.com/JuliaPlots/PlotlyKaleido.jl/tree/main#windows-note for more details."
+        end
 
-If you think this is not your case, you might try using a longer timeout to check if the process is not responding (defaults to 10 seconds) by passing the desired value in seconds using the `timeout` kwarg when calling `PlotlyKaleido.start` or `PlotlyKaleido.restart`")
+        warn_str *= "
+Alternatively, you might try using a longer timeout to check if the process is not responding by passing the desired value in seconds using the `timeout` kwarg when calling `PlotlyKaleido.start` or `PlotlyKaleido.restart`"
+        warn_and_kill(warn_str)
+    end
     return out
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,12 @@ import Pkg
 @test_nowarn @eval using PlotlyKaleido
 
 @testset "Start" begin
-    @test_nowarn PlotlyKaleido.start()
+    if Sys.iswindows()
+        # We use @test_logs without log patterns to test that no @warn is thrown, as specified in the docstring of `@test_logs`
+        @test_logs PlotlyKaleido.start()
+    else
+        @test_nowarn PlotlyKaleido.start()
+    end
     @test PlotlyKaleido.is_running()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,11 @@
 using Test
 import Pkg
-if Sys.iswindows()
-    # Fix kaleido tests on windows due to Kaleido_jll@v0.2.1 hanging
-    Pkg.add(;name = "Kaleido_jll", version = "0.1")
-end
 @test_nowarn @eval using PlotlyKaleido
 
-    @testset "Start" begin
-    if Sys.iswindows()
-        PlotlyKaleido.start()
-    else
-        @test_nowarn PlotlyKaleido.start()
-    end
+@testset "Start" begin
+    @test_nowarn PlotlyKaleido.start()
     @test PlotlyKaleido.is_running()
 end
-
 
 import PlotlyLight, EasyConfig, PlotlyJS
 
@@ -62,5 +53,4 @@ end
 @testset "Shutdown" begin
     PlotlyKaleido.kill_kaleido()
     @test !PlotlyKaleido.is_running()
-
 end


### PR DESCRIPTION
This PR tries to implement the solution mentioned on discourse [here](https://discourse.julialang.org/t/different-compat-needs-on-windows-vs-mac-linux/124384/3?u=disberd).

It seems that the upstream Kaleido library is shifting towards becoming a python only solution that will not shipped a stripped down compiled version of chromium as a binary, but will assume the user has chrome/chromium installed on its system.

Due to this, it is likely that we'll never see new version of the original library that will fix windows issues and be compatible with our current Artifact based solution.

Luckily, it seems that reverting to 0.1 on Windows solves the issue (I have not found any missing functionality on Windows in 0.1, and looking at the [changelog for 0.2.0](https://github.com/plotly/Kaleido/releases/tag/v0.2.0) there doesn't seem to be any signficant change for us julia users).

This PR simply adds explicit artifacts pointing to the 0.1 version shipped with Kaleido_jll just on windows systems.

It also adds a flag that to specify whether to use the manually provided version 0.1 of kaleido. This flag defaults to `true` on Windows systems and if the installed version of Kaleido_jll is not already 0.1.

I believe that with this change we could potentially solve a lot of hassle for windows users automatically, and it will still be possible for people facing some issues with this to manually set the flag to false before running `PlotlyKaleido.start()`.

With this fix, it should be possible to solve the original problem raised on [discourse](https://discourse.julialang.org/t/different-compat-needs-on-windows-vs-mac-linux/124384).