### PR TITLE
Setup Javascript resources to use released artifacts by default

### DIFF
--- a/.github/workflows/BuildArtifacts.yml
+++ b/.github/workflows/BuildArtifacts.yml
@@ -1,0 +1,66 @@
+name: Build Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      js:
+        description: 'Javascript Resource'
+        required: true
+        type: choice
+        options:
+          - mathjax
+          - plotly
+      version:
+        description: 'Upstream Version Number'
+        required: true
+        type: string
+      buildid:
+        description: 'Release Build ID (+suffix)'
+        required: true
+        type: number
+        default: 0
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+
+      - name: Build Artifacts
+        id: build
+        shell: julia --color=yes {0}
+        run: |
+          using Pkg: Artifacts
+          js, ver, bld, repo = "${{ inputs.js }}", "${{ inputs.version}}", ${{ inputs.buildid }}, "${{ github.repository }}"
+          url = Dict("mathjax" => "https://cdnjs.cloudflare.com/ajax/libs/mathjax/$ver/MathJax.js",
+                     "plotly" => "https://cdn.plot.ly/plotly-$ver.js")[js]
+          h = Artifacts.create_artifact() do dir
+            @info "downloading $url"
+            download(url, joinpath(dir, "$js.js"))
+          end
+          dh = Artifacts.archive_artifact(h, joinpath("_build", "$js.tar.gz"))
+          release_url = "https://github.com/$repo/releases/download/$js-$ver+$bld/$js.tar.gz"
+          Artifacts.bind_artifact!("Artifacts.toml", js, h, force=true, download_info=[(release_url, dh)])
+          @info """Success: artifact"$js" bound to $release_url"""
+          @info """  artifact"$js" -> $h"""
+          @info """  $js.tar.gz -> $dh"""
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "_build/*.tar.gz"
+          tag: "${{ inputs.js }}-${{ inputs.version }}+${{ inputs.buildid }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "Update ${{ inputs.js }} artifact to v${{ inputs.version }}+${{ inputs.buildid }}"
+          body: "This is an automated pull request to update the ${{ inputs.js }} artifact corresponding to the release https://github.com/${{ github.repository }}/releases/tag/${{ inputs.js }}-${{ inputs.version }}+${{ inputs.buildid }}."

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Manifest.toml
 *.png
+_build

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -15,6 +15,13 @@ os = "windows"
     sha256 = "52bce20e749b9955ee4dd3b22fa44dbdc9a6c4a4d447e243d8c016d4b730d496"
     url = "https://github.com/JuliaBinaryWrappers/Kaleido_jll.jl/releases/download/Kaleido-v0.1.0+0/Kaleido.v0.1.0.x86_64-w64-mingw32.tar.gz"
 
+[mathjax]
+git-tree-sha1 = "792d2df4cd187b4dc5708917ce584ef855fffe8a"
+
+    [[mathjax.download]]
+    sha256 = "941755badc098140f52ca8bac64debe542f62ca444fe1708dba0bee240462c0f"
+    url = "https://github.com/mbauman/PlotlyKaleido.jl/releases/download/mathjax-2.7.9+0/mathjax.tar.gz"
+
 [plotly]
 git-tree-sha1 = "d0e03b7c1e3e18db75491b2175aab69b08695b5f"
 

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -14,3 +14,10 @@ os = "windows"
     [[Kaleido_fallback.download]]
     sha256 = "52bce20e749b9955ee4dd3b22fa44dbdc9a6c4a4d447e243d8c016d4b730d496"
     url = "https://github.com/JuliaBinaryWrappers/Kaleido_jll.jl/releases/download/Kaleido-v0.1.0+0/Kaleido.v0.1.0.x86_64-w64-mingw32.tar.gz"
+
+[plotly]
+git-tree-sha1 = "d0e03b7c1e3e18db75491b2175aab69b08695b5f"
+
+    [[plotly.download]]
+    sha256 = "cb1c0fcdffe3e7d87fe582810c22f5be3346e017a66b7f6e56b502a0040cafb2"
+    url = "https://github.com/mbauman/PlotlyKaleido.jl/releases/download/plotly-2.35.2+2/plotly.tar.gz"

--- a/src/PlotlyKaleido.jl
+++ b/src/PlotlyKaleido.jl
@@ -114,19 +114,22 @@ function start(;
     push!(BIN.exec, "plotly")
     chromium_flags = ["--disable-gpu", Sys.isapple() ? "--single-process" : "--no-sandbox"]
     extra_flags = if plotly_version === missing
-        (; kwargs...)
+        (; plotlyjs = string("file://", artifact"plotly/plotly.js"))
     else
         # We create a plotlyjs flag pointing at the specified plotly version
         (; plotlyjs = "https://cdn.plot.ly/plotly-$(plotly_version).min.js", kwargs...)
     end
-    if !(mathjax === missing)
+    if mathjax === missing
+        mathjaxfile = string("file://", artifact"mathjax/mathjax.js")
+        push!(chromium_flags, "--mathjax=$mathjaxfile")
+    else
         if mathjax_version > _mathjax_last_version
             error(
                 "The given mathjax version ($(mathjax_version)) is greater than the last supported version ($(_mathjax_last_version)) of Kaleido.",
             )
         end
-        if mathjax isa Bool && mathjax
-            push!(
+        if mathjax isa Bool
+            mathjax && push!(
                 chromium_flags,
                 "--mathjax=$(_mathjax_url_path)/$(mathjax_version)/MathJax.js",
             )


### PR DESCRIPTION
There are three parts to this pull request, and this can easily be split apart if that's preferred.

* f9ffcb0a76a3f423f4549b600ab16cf552d66f52: Creates a GitHub Action that allows you to create releases of the two javascript dependencies directly on JuliaPlots/PlotlyKaleido.jl.  It's a [manually triggered action](https://github.com/mbauman/PlotlyKaleido.jl/actions/runs/13955687751) that allows you to set the desired version number.  It downloads the given javascript resource for the given version, uploads it as [a release artifact](https://github.com/mbauman/PlotlyKaleido.jl/releases), and then creates [pull request](https://github.com/mbauman/PlotlyKaleido.jl/pull/5)([s](https://github.com/mbauman/PlotlyKaleido.jl/issues/4)) to update the Artifacts.toml as needed.
    <img src="https://github.com/user-attachments/assets/a893b8a0-3729-4bcc-9475-54bb14a70be2" width="450">

* f41323d5d0e6e130e58df9fbb6878bf16e50b6cd & a308b5dedce3ec330bfada094257118d1be476fb: Are the results of merging https://github.com/mbauman/PlotlyKaleido.jl/pull/4 and https://github.com/mbauman/PlotlyKaleido.jl/pull/5 on my fork.
* 5b462a0b1f551787868a568e0337b7a4d5577739: is a minimally invasive patch to default to using these artifacts **from my fork**.

-----------

There are two paths forward here, and I'm happy to help make either happen:
- merge this PR as is, and then an owner here triggers the plotly and mathjax release builds (and subsequent PRs) to move update the Artifact.toml to use those official releases.
- I can split this to just contain f9ffcb0a76a3f423f4549b600ab16cf552d66f52, then an owner here can trigger the actions, then merge the auto-generated PRs, then I can submit f41323d5d0e6e130e58df9fbb6878bf16e50b6cd.

Fixes #26.